### PR TITLE
Improve manual release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ coverage/
 *.swo
 .claude-memory.md
 scripts/manual-release.sh
-scripts/manual-release.sh

--- a/scripts/manual-release.sh
+++ b/scripts/manual-release.sh
@@ -47,6 +47,12 @@ echo "📤 Pushing to GitHub..."
 git push origin main
 git push origin "v$NEW_VERSION"
 
+# Get the commit message for the release notes
+COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+
+echo "📢 Creating GitHub release..."
+gh release create "v$NEW_VERSION" --target main --title "v$NEW_VERSION" --notes "$COMMIT_MESSAGE"
+
 echo ""
 echo "✅ Manual release complete!"
 echo "📋 Version: $NEW_VERSION"


### PR DESCRIPTION
## Changes

- Remove duplicate gitignore entry for manual-release.sh
- Add GitHub release creation to manual release workflow
- Use commit message as release notes

## Implementation

Added `gh release create` command to the manual-release.sh script to automatically create GitHub releases with the commit message as release notes.

## Testing

- Script builds and commits successfully
- Release workflow enhanced