### PR TITLE
Fix API path inconsistencies - use /api/v1 prefix

### DIFF
--- a/src/core/zhtp-api-methods.ts
+++ b/src/core/zhtp-api-methods.ts
@@ -372,7 +372,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   // ==================== Network Operations ====================
 
   async getNetworkInfo(): Promise<NetworkStatus> {
-    return this.request<NetworkStatus>('/mesh/peers');
+    return this.request<NetworkStatus>('/api/v1/blockchain/network/peers');
   }
 
   // ==================== Wallet & Transaction Operations ====================
@@ -409,7 +409,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     amount: number,
     metadata?: Record<string, any>
   ): Promise<Transaction> {
-    return this.request<Transaction>('/wallet/send', {
+    return this.request<Transaction>('/api/v1/wallet/send', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ from, to, amount, metadata }),
@@ -419,7 +419,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   // ==================== DAO Operations ====================
 
   async getDaoProposals(): Promise<DaoProposal[]> {
-    return this.request<DaoProposal[]>('/dao/proposals');
+    return this.request<DaoProposal[]>('/api/v1/dao/proposals/list');
   }
 
   async getDaoStats(): Promise<DaoStats> {
@@ -447,7 +447,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   }
 
   async createProposal(proposal: any): Promise<DaoProposal> {
-    return this.request<DaoProposal>('/dao/proposals', {
+    return this.request<DaoProposal>('/api/v1/dao/proposals', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(proposal),
@@ -459,7 +459,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     vote: boolean,
     voterDid: string
   ): Promise<void> {
-    await this.request<void>('/dao/vote', {
+    await this.request<void>('/api/v1/dao/vote/cast', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ proposalId, vote, voterDid }),
@@ -467,7 +467,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   }
 
   async getDaoTreasury(): Promise<number> {
-    const response = await this.request<any>('/dao/treasury');
+    const response = await this.request<any>('/api/v1/dao/treasury/balance');
     return response?.balance || 0;
   }
 
@@ -476,11 +476,11 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   }
 
   async getDaoData(): Promise<Record<string, any>> {
-    return this.request<Record<string, any>>('/dao/data');
+    return this.request<Record<string, any>>('/api/v1/dao/data');
   }
 
   async getDaoDelegates(): Promise<Delegate[]> {
-    return this.request<Delegate[]>('/dao/delegates');
+    return this.request<Delegate[]>('/api/v1/dao/delegates');
   }
 
   async getDelegateProfile(delegateId: string): Promise<Delegate> {
@@ -488,7 +488,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   }
 
   async registerDelegate(userDid: string, delegateInfo: Record<string, any>): Promise<Delegate> {
-    return this.request<Delegate>('/dao/delegates/register', {
+    return this.request<Delegate>('/api/v1/dao/delegates/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ userDid, delegateInfo }),
@@ -496,7 +496,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   }
 
   async revokeDelegation(userDid: string): Promise<void> {
-    await this.request<void>('/dao/delegates/revoke', {
+    await this.request<void>('/api/v1/dao/delegates/revoke', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ userDid }),
@@ -504,11 +504,11 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   }
 
   async getTreasuryHistory(): Promise<TreasuryRecord[]> {
-    return this.request<TreasuryRecord[]>('/dao/treasury/history');
+    return this.request<TreasuryRecord[]>('/api/v1/dao/treasury/history');
   }
 
   async createSpendingProposal(proposalData: Record<string, any>): Promise<DaoProposal> {
-    return this.request<DaoProposal>('/dao/proposals/spending', {
+    return this.request<DaoProposal>('/api/v1/dao/proposals/spending', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(proposalData),
@@ -572,19 +572,19 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
   // ==================== Blockchain Operations ====================
 
   async getBlockchainInfo(): Promise<any> {
-    return this.request<any>('/blockchain/info');
+    return this.request<any>('/api/v1/blockchain/status');
   }
 
   async getGasInfo(): Promise<any> {
-    return this.request<any>('/network/gas');
+    return this.request<any>('/api/v1/network/gas');
   }
 
   async getNodeStatus(): Promise<NodeStatus> {
-    return this.request<NodeStatus>('/node/status');
+    return this.request<NodeStatus>('/api/v1/protocol/info');
   }
 
   async getMeshPeers(): Promise<{ peers: string[]; count: number }> {
-    return this.request<{ peers: string[]; count: number }>('/mesh/peers');
+    return this.request<{ peers: string[]; count: number }>('/api/v1/blockchain/network/peers');
   }
 
   async getNetworkStats(): Promise<{
@@ -709,7 +709,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
 
   async getProtocolInfo() {
     try {
-      const response = await this.request<any>('/node/status');
+      const response = await this.request<any>('/api/v1/protocol/info');
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
Updates all API endpoint paths to use the `/api/v1` prefix for consistency with the ZHTP node implementation.

## Changes
- Updated 17 endpoint paths in `src/core/zhtp-api-methods.ts`
- DAO endpoints: `/dao/*` → `/api/v1/dao/*`
- Blockchain endpoints: `/blockchain/info` → `/api/v1/blockchain/status`
- Network endpoints: `/mesh/peers` → `/api/v1/blockchain/network/peers`
- Protocol endpoints: `/node/status` → `/api/v1/protocol/info`
- Gas info: `/network/gas` → `/api/v1/network/gas`

## Endpoints Updated
1. Network info: `/mesh/peers` → `/api/v1/blockchain/network/peers`
2. Wallet send: `/wallet/send` → `/api/v1/wallet/send`
3. Get proposals: `/dao/proposals` → `/api/v1/dao/proposals/list`
4. Create proposal: `/dao/proposals` → `/api/v1/dao/proposals`
5. Submit vote: `/dao/vote` → `/api/v1/dao/vote/cast`
6. Get treasury: `/dao/treasury` → `/api/v1/dao/treasury/balance`
7. Get DAO data: `/dao/data` → `/api/v1/dao/data`
8. Get delegates: `/dao/delegates` → `/api/v1/dao/delegates`
9. Register delegate: `/dao/delegates/register` → `/api/v1/dao/delegates/register`
10. Revoke delegation: `/dao/delegates/revoke` → `/api/v1/dao/delegates/revoke`
11. Treasury history: `/dao/treasury/history` → `/api/v1/dao/treasury/history`
12. Spending proposals: `/dao/proposals/spending` → `/api/v1/dao/proposals/spending`
13. Blockchain info: `/blockchain/info` → `/api/v1/blockchain/status`
14. Gas info: `/network/gas` → `/api/v1/network/gas`
15. Node status (1st): `/node/status` → `/api/v1/protocol/info`
16. Mesh peers (2nd): `/mesh/peers` → `/api/v1/blockchain/network/peers`
17. Node status (2nd): `/node/status` → `/api/v1/protocol/info`

## Testing
- All paths now align with ZHTP node router aliases
- Node supports backward compatibility via path aliasing

Fixes #7