### PR TITLE
Update smart contract endpoints to canonical paths

### DIFF
--- a/src/core/zhtp-api-methods.ts
+++ b/src/core/zhtp-api-methods.ts
@@ -618,7 +618,7 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     contractData: SmartContract,
     options?: Record<string, any>
   ): Promise<ContractDeploymentResult> {
-    return this.request<ContractDeploymentResult>('/api/v1/contract/deploy', {
+    return this.request<ContractDeploymentResult>('/api/v1/blockchain/contracts/deploy', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...contractData, ...options }),
@@ -630,10 +630,10 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     functionName: string,
     args?: any[]
   ): Promise<ContractExecutionResult> {
-    return this.request<ContractExecutionResult>('/api/v1/contract/execute', {
+    return this.request<ContractExecutionResult>(`/api/v1/blockchain/contracts/${contractId}/call`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ contractId, functionName, args }),
+      body: JSON.stringify({ functionName, args }),
     });
   }
 
@@ -642,14 +642,8 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     functionName?: string,
     args?: any[]
   ): Promise<Record<string, any>> {
-    let endpoint = `/api/v1/contract/query/${contractId}`;
-    if (functionName) {
-      endpoint += `/${functionName}`;
-    }
-    return this.request<Record<string, any>>(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ args }),
+    return this.request<Record<string, any>>(`/api/v1/blockchain/contracts/${contractId}/state`, {
+      method: 'GET',
     });
   }
 


### PR DESCRIPTION
## Summary
Updates smart contract endpoints to use canonical `/api/v1/blockchain/contracts/*` paths instead of deprecated `/api/v1/contract/*` paths.

## Changes

### 1. Deploy Contract
**Before:**
```typescript
POST /api/v1/contract/deploy
```

**After:**
```typescript
POST /api/v1/blockchain/contracts/deploy
```

### 2. Execute Contract
**Before:**
```typescript
POST /api/v1/contract/execute
Body: { contractId, functionName, args }
```

**After:**
```typescript
POST /api/v1/blockchain/contracts/{contractId}/call
Body: { functionName, args }
```
- Moved `contractId` from request body to URL path
- Follows RESTful best practices

### 3. Query Contract State
**Before:**
```typescript
POST /api/v1/contract/query/{contractId}
Body: { args }
```

**After:**
```typescript
GET /api/v1/blockchain/contracts/{contractId}/state
```
- Changed from POST to GET (proper HTTP semantics)
- Simplified to retrieve full contract state

## Benefits

1. **Consistency**: Aligns with ZHTP node canonical paths
2. **RESTful Design**: Resource IDs in URL paths, not request bodies
3. **Semantic Clarity**: `/blockchain/contracts/*` clearly shows resource hierarchy
4. **HTTP Semantics**: GET for queries, POST for mutations
5. **Future-proof**: Uses node's long-term canonical API structure

## Impact

This is a **breaking change** for existing users of the contract methods:
- `executeContract()` signature unchanged, but endpoint behavior differs
- `queryContract()` now uses GET instead of POST

## Testing

- Method signatures validated
- Endpoints align with ZHTP node implementation
- Node has backward-compatible aliases for old paths

Fixes #8