### PR TITLE
Add Web4/DHT domain resolution methods

### DIFF
--- a/src/core/zhtp-api-methods.ts
+++ b/src/core/zhtp-api-methods.ts
@@ -557,8 +557,12 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     return this.request<any>(endpoint);
   }
 
-  async getContractByHash(hash: string): Promise<any> {
-    return this.request<any>(`/api/v1/blockchain/contract/${hash}`);
+  /**
+   * Lookup contract by blockchain transaction hash
+   * @param hash - Deployment transaction hash
+   */
+  async getContractByHash(hash: string): Promise<SmartContract> {
+    return this.request<SmartContract>(`/api/v1/blockchain/contract/${hash}`);
   }
 
   async getContractById(contractId: string): Promise<SmartContract> {
@@ -567,6 +571,22 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
 
   async resolveDomain(domainName: string): Promise<DApp> {
     return this.request<DApp>(`/api/v1/web4/resolve/${encodeURIComponent(domainName)}`);
+  }
+
+  /**
+   * Resolve Web4 domain via DHT network
+   * @param domain - Domain name (e.g., "example.zhtp")
+   */
+  async resolveWeb4ViaDht(domain: string): Promise<DApp> {
+    return this.request<DApp>(`/api/v1/dht/web4/resolve/${encodeURIComponent(domain)}`);
+  }
+
+  /**
+   * Get contract from DHT distributed storage
+   * @param contractId - Contract identifier
+   */
+  async getContractFromDht(contractId: string): Promise<SmartContract> {
+    return this.request<SmartContract>(`/api/v1/dht/contract/${contractId}`);
   }
 
   // ==================== Blockchain Operations ====================


### PR DESCRIPTION
## Summary
Adds Web4/DHT domain resolution methods to support decentralized domain resolution and contract retrieval from DHT storage.

## Changes

### 1. New Method: `resolveWeb4ViaDht()`
```typescript
/**
 * Resolve Web4 domain via DHT network
 * @param domain - Domain name (e.g., "example.zhtp")
 */
async resolveWeb4ViaDht(domain: string): Promise<DApp> {
  return this.request<DApp>(`/api/v1/dht/web4/resolve/${encodeURIComponent(domain)}`);
}
```
**Endpoint:** `GET /api/v1/dht/web4/resolve/{domain}`

### 2. New Method: `getContractFromDht()`
```typescript
/**
 * Get contract from DHT distributed storage
 * @param contractId - Contract identifier
 */
async getContractFromDht(contractId: string): Promise<SmartContract> {
  return this.request<SmartContract>(`/api/v1/dht/contract/${contractId}`);
}
```
**Endpoint:** `GET /api/v1/dht/contract/{contractId}`

### 3. Improved Method: `getContractByHash()`
```typescript
/**
 * Lookup contract by blockchain transaction hash
 * @param hash - Deployment transaction hash
 */
async getContractByHash(hash: string): Promise<SmartContract>
```
- Added JSDoc documentation
- Fixed return type from `any` to `SmartContract`
- Already uses correct endpoint: `GET /api/v1/blockchain/contract/{hash}`

## Benefits

1. **Complete Web4 Support**: Enables DHT-based domain resolution for decentralized apps
2. **Contract Discovery**: Retrieve contracts from distributed storage
3. **Blockchain Lookup**: Find contracts by transaction hash
4. **Type Safety**: All methods use proper TypeScript types
5. **Documentation**: JSDoc comments for better IDE support

## Dependencies

**Blocked by:** Node Issue #113 - Missing Web4/DHT resolution endpoints

These methods will work once the ZHTP node implements:
- `GET /api/v1/dht/web4/resolve/{domain}`
- `GET /api/v1/dht/contract/{id}`
- `GET /api/v1/blockchain/contract/{hash}` (already exists)

## Notes

- Methods follow existing patterns in the codebase
- Domain names are URL-encoded to handle special characters
- Return types use existing `DApp` and `SmartContract` interfaces
- Ready for use once node endpoints are deployed

Fixes #9