### PR TITLE
Improve getGasInfo() type safety

### DIFF
--- a/src/core/zhtp-api-methods.ts
+++ b/src/core/zhtp-api-methods.ts
@@ -595,8 +595,8 @@ export abstract class ZhtpApiMethods extends ZhtpApiCore {
     return this.request<any>('/api/v1/blockchain/status');
   }
 
-  async getGasInfo(): Promise<any> {
-    return this.request<any>('/api/v1/network/gas');
+  async getGasInfo(): Promise<GasInfo> {
+    return this.request<GasInfo>('/api/v1/network/gas');
   }
 
   async getNodeStatus(): Promise<NodeStatus> {


### PR DESCRIPTION
## Summary
Updates `getGasInfo()` method to use proper TypeScript type instead of `any` for better type safety.

## Changes

### Type Safety Improvement
**Before:**
```typescript
async getGasInfo(): Promise<any> {
  return this.request<any>('/api/v1/network/gas');
}
```

**After:**
```typescript
async getGasInfo(): Promise<GasInfo> {
  return this.request<GasInfo>('/api/v1/network/gas');
}
```

## Benefits

1. **Type Safety**: Developers get IntelliSense and compile-time type checking
2. **Better IDE Support**: Auto-completion for gas info properties
3. **Catch Errors Early**: TypeScript catches misuse at build time
4. **Documentation**: `GasInfo` interface documents expected response structure

## GasInfo Interface

Already defined in `src/core/types.ts`:
```typescript
export interface GasInfo {
  gasPrice: number;
  estimatedCost: number;
  baseFee?: number;
  priorityFee?: number;
}
```

## Notes

- Path already updated to `/api/v1/network/gas` in PR #13 (Issue #7)
- Only return type changed for better type safety
- No breaking changes to method signature
- Method will work once node implements endpoint (blocked by node Issue #112)

Fixes #10